### PR TITLE
Enhance FormulaFilter to gracefully handle nulls

### DIFF
--- a/trigger-actions-framework/main/default/classes/FormulaFilter.cls
+++ b/trigger-actions-framework/main/default/classes/FormulaFilter.cls
@@ -103,7 +103,7 @@ global class FormulaFilter {
 			);
 			toProcess.newSobject = record;
 			toProcess.oldSobject = recordPrior;
-			if ((Boolean) fx.evaluate(toProcess)) {
+			if ((Boolean) fx.evaluate(toProcess) == true) {
 				result.triggerNew.add(record);
 				result.triggerOld.add(recordPrior);
 			}

--- a/trigger-actions-framework/main/default/classes/FormulaFilterTest.cls
+++ b/trigger-actions-framework/main/default/classes/FormulaFilterTest.cls
@@ -16,7 +16,7 @@
 @SuppressWarnings(
 	'PMD.ApexUnitTestClassShouldHaveRunAs, PMD.AvoidGlobalModifier'
 )
-@IsTest
+@IsTest(IsParallel=true)
 global class FormulaFilterTest {
 	private static final String ACCOUNT_SOBJECT_NAME = 'Account';
 	private static final String EXCEPTION_SHOULD_BE_THROWN = 'An exception should be thrown';
@@ -324,6 +324,33 @@ global class FormulaFilterTest {
 			),
 			caught.getMessage(),
 			'The exception message should match the expected error'
+		);
+	}
+
+	@IsTest
+	private static void formulaEvaluatingToNullShouldBeTreatedAsFalse() {
+		triggerNew[1].Description = 'example 1';
+		configuration.Entry_Criteria__c = 'CONTAINS(record.Description, "example")';
+		FormulaFilter filter = new FormulaFilter(
+			configuration,
+			TriggerOperation.BEFORE_UPDATE,
+			ACCOUNT_SOBJECT_NAME
+		);
+
+		FormulaFilter.Result result = filter.filterByEntryCriteria(
+			triggerNew,
+			triggerOld
+		);
+
+		System.Assert.areEqual(
+			1,
+			result.triggerNew.size(),
+			'Only 1 record should be processed when CONTAINS evaluates to null for the first record'
+		);
+		System.Assert.areEqual(
+			1,
+			result.triggerOld.size(),
+			'Only 1 record should be processed when CONTAINS evaluates to null for the first record'
 		);
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls
@@ -15,7 +15,7 @@
  */
 
 @SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
-@IsTest
+@IsTest(IsParallel=true)
 private class TriggerActionFlowAddErrorTest {
 	private static final String MY_STRING = 'MY_STRING';
 	private static final String NAME = 'Name';

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
@@ -15,7 +15,7 @@
  */
 
 @SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
-@IsTest
+@IsTest(IsParallel=true)
 private class TriggerActionFlowClearBypassTest {
 	private static final String MY_STRING = 'MY_STRING';
 	private static List<TriggerActionFlowClearBypass.Request> requests = new List<TriggerActionFlowClearBypass.Request>();

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
@@ -15,7 +15,7 @@
  */
 
 @SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
-@IsTest
+@IsTest(IsParallel=true)
 private class TriggerActionFlowIsBypassedTest {
 	private static final String MY_STRING = 'MY_STRING';
 	private static List<TriggerActionFlowIsBypassed.Request> requests = new List<TriggerActionFlowIsBypassed.Request>();


### PR DESCRIPTION
- Update FormulaFilter to explicitly check for true in evaluation condition.
- Add test case to handle scenarios where formula evaluation results in null.
- Modify test classes to run in parallel for better performance.

Fixes #183

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
